### PR TITLE
Update Discuss link for GSA not NARA

### DIFF
--- a/pages/index.md
+++ b/pages/index.md
@@ -14,7 +14,7 @@ description: ""
 
 <ul>
   <li dir="ltr">
-  <p dir="ltr">Discuss on Github: We have published this plan on Github so that you can easily provide comments through the “<a href="https://github.com/usnationalarchives/opengovplan/issues/" target="_blank">Discuss</a>” feature located on the upper right or bottom left of each page. Select “Discuss” and then “New issue” or comment on existing issues. You will need to create a Github Account to create an issue.</p>
+  <p dir="ltr">Discuss on Github: We have published this plan on Github so that you can easily provide comments through the “<a href="https://github.com/GSA/opengovplan/issues" target="_blank">Discuss</a>” feature located on the upper right or bottom left of each page. Select “Discuss” and then “New issue” or comment on existing issues. You will need to create a Github Account to create an issue.</p>
   </li>
   <li dir="ltr">
   <p dir="ltr">Edit on Github: We have published this plan on Github so that you can also provide suggested edits by submitting a pull request with the specific language changes. Select the “Edit” function on the upper right or bottom left of any page to make a suggested language edit to that page. You will need to create a Github Account to submit a suggested edit through a pull request. </p>


### PR DESCRIPTION
I assume we want discussions specific to our agency vs. pushing GSA-specific discussion (e.g. on our open plan) to another agency's forum.
